### PR TITLE
Fix Factory Reset when FlashCast is used as recovery image

### DIFF
--- a/bundled-mods/factory-reset/flasher.sh
+++ b/bundled-mods/factory-reset/flasher.sh
@@ -1,0 +1,5 @@
+set -e
+
+# Wipe Data Partition
+log "Erasing /data partition"
+clear_data

--- a/mod-flasher/flasher
+++ b/mod-flasher/flasher
@@ -123,7 +123,7 @@ else
 			IGNORE_ERRORS=1
 		fi
 		log_cmd flash-image '/usr/share/flasher/iterate-images' "${IMAGES_DIR}/flashcast-mods" "$IGNORE_ERRORS"
-	elif test "$FTS_BOOT_MODE" = "recovery" && test "$IMAGES_DEVICE" = "/dev/mtdblock4" ; then
+	elif test "$FTS_BOOT_MODE" = "recovery" && test "$IMAGES_DEVICE" = "/dev/mtdblock4" && ! test -f "${IMAGES_DIR}/no_reboot" ; then
 		# We do this so factory resets work, otherwise we sit in recovery.
 		log "No images found on ${IMAGES_DEVICE}, assuming factory reset"
 		log_cmd flash-image '/usr/share/flasher/factory-reset'

--- a/mod-flasher/flasher
+++ b/mod-flasher/flasher
@@ -2,6 +2,7 @@
 set -o pipefail
 
 LOG_FILES='/root/flashcast.log'
+FTS_BOOT_MODE="$(fts-get bootloader.command | sed -e 's/^boot-//')"
 
 log_cmd() {
 	"$@" 2>&1 | tee -a $LOG_FILES
@@ -19,7 +20,6 @@ fatal() {
 
 select_images_device() {
 	CMDLINE_BOOT_MODE="$(sed -re 's/.*\bandroidboot\.mode=(\w+)\b.*/\1/' /proc/cmdline)"
-	FTS_BOOT_MODE="$(fts-get bootloader.command | sed -e 's/^boot-//')"
 	if test -z "$FTS_BOOT_MODE" ; then
 		FTS_BOOT_MODE='normal'
 	fi
@@ -123,6 +123,11 @@ else
 			IGNORE_ERRORS=1
 		fi
 		log_cmd flash-image '/usr/share/flasher/iterate-images' "${IMAGES_DIR}/flashcast-mods" "$IGNORE_ERRORS"
+	elif test "$FTS_BOOT_MODE" = "recovery" && test "$IMAGES_DEVICE" = "/dev/mtdblock4" ; then
+		# We do this so factory resets work, otherwise we sit in recovery.
+		log "No images found on ${IMAGES_DEVICE}, assuming factory reset"
+		log_cmd flash-image '/usr/share/flasher/factory-reset'
+		
 	else
 		fatal "No images found on ${IMAGES_DEVICE}"
 	fi


### PR DESCRIPTION
When a factory reset is called to the ChromeCast, it boots into recovery to wipe data. This will check the chromecast to make sure the FTS boot mode is set to recovery, and we are running from recovery, no_reboot is not set, and no flashable images/files were found. 
