### PR TITLE
Add Support for Partition Backup and Restores

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ There are also a set of mods which ship with FlashCast and are called by
 - `remove-ota`: This mod is run on every FlashCast boot. It removes `ota.zip`
     and `temp-ota.zip` from the cache MTD partition in case an update was
     partially downloaded by the stock OS.
+- `full-backup`: This mod is run when a `full_backup` flag file is present. It
+    creates a backup of /system, /userdata, and the kernel to a unique folder in 
+    the folder `flashcast-backups`.
+- `full-restore`: This mod is run when a `full_restore` flag file is present. It
+    will restore a that was made using `full-backup`. Please read the flag documentation
+    on how to select which backup to restore.

--- a/bundled-mods/full-backup/imager.sh
+++ b/bundled-mods/full-backup/imager.sh
@@ -1,9 +1,6 @@
 set -e
 
 backup_mtd_partition 'rootfs'
-
 backup_mtd_partition 'kernel'
-
 backup_mtd_partition 'recovery'
-
 backup_mtd_partition 'userdata'

--- a/bundled-mods/full-backup/imager.sh
+++ b/bundled-mods/full-backup/imager.sh
@@ -1,0 +1,9 @@
+set -e
+
+backup_mtd_partition 'rootfs'
+
+backup_mtd_partition 'kernel'
+
+backup_mtd_partition 'recovery'
+
+backup_mtd_partition 'userdata'

--- a/bundled-mods/full-restore/imager.sh
+++ b/bundled-mods/full-restore/imager.sh
@@ -1,16 +1,13 @@
 set -e
 
 if test -z "$1" ; then
-        fatal "No Backup Folder Defined in full_backup"
+        fatal "No Backup Folder Defined in full_restore"
 fi
 
 # $1 should be the folder number of your backup, ex 1 for ./backup-1
 # it should NOT be a full path!
 
 restore_mtd_partition 'rootfs' "$1"
-
 restore_mtd_partition 'kernel' "$1"
-
 restore_mtd_partition 'recovery' "$1"
-
 restore_mtd_partition 'userdata' "$1"

--- a/bundled-mods/full-restore/imager.sh
+++ b/bundled-mods/full-restore/imager.sh
@@ -1,0 +1,16 @@
+set -e
+
+if test -z "$1" ; then
+        fatal "No Backup Folder Defined in full_backup"
+fi
+
+# $1 should be the folder number of your backup, ex 1 for ./backup-1
+# it should NOT be a full path!
+
+restore_mtd_partition 'rootfs' "$1"
+
+restore_mtd_partition 'kernel' "$1"
+
+restore_mtd_partition 'recovery' "$1"
+
+restore_mtd_partition 'userdata' "$1"

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -15,3 +15,13 @@ supported flag files are listed below:
     a single mod won't halt the entire flashing process.
 - `no_reboot`: If present, FlashCast will not reboot the device after a
     successful flash.
+- `full_backup`: If present, FlashCast will backup the System, Recovery, Kernel, and
+    UserData partitions into a folder called `flashcast-backups` before any mods are flashed.
+    This feature should **ONLY** be used by developers. This feature is currently in Alpha, and
+    should not be relied on at this time.
+- `full_restore`: If present, FlashCast will restore a backup that was made with the `full_backup` flag.
+    When this file is created, please place a number in the file, ex 1, to tell flashcast which backup to restore.
+    For example, if the backup you want to restore is in `flashcast-backups/backup-2/` then you would put `2` inside of 
+    `full_restore`.
+    This feature should **ONLY** be used by developers. This feature is currently in Alpha, and
+    should not be relied on at this time.

--- a/src/flash-image
+++ b/src/flash-image
@@ -94,22 +94,22 @@ backup_mtd_partition() {
 	fi
 	
 	# I know this is bad, but we can't store this in /tmp if images are there due to space
-	_TEMPMOUNT="$(mktemp -d)"
-	if ! mount "/dev/sda1" "$_TEMPMOUNT" ; then
-		log "Could not mount /dev/sda1 to $_TEMPMOUNT"
-		rm -r ${_TEMPMOUNT}
+	_TEMP_MOUNT="$(mktemp -d)"
+	if ! mount "/dev/sda1" "$_TEMP_MOUNT" ; then
+		log "Could not mount /dev/sda1 to $_TEMP_MOUNT"
+		rm -r ${_TEMP_MOUNT}
 		return 1;
 	fi
 
 	# Do we know the mount point? We do this so all backups go to the same folder
 	if ! test -f "/tmp/backup_dir" ; then
 		I=1
-		while test -d "$_TEMPMOUNT/flashcast-backups/backup-${I}/" ; do
+		while test -d "$_TEMP_MOUNT/flashcast-backups/backup-${I}/" ; do
                 	I="$((I+1))"
 		done
-		dry_run "Would create $_TEMPMOUNT/flashcast-backups/backup-${I}"
+		dry_run "Would create $_TEMP_MOUNT/flashcast-backups/backup-${I}"
 		if test -z "$DRY_RUN" ; then
-			mkdir -p "$_TEMPMOUNT/flashcast-backups/backup-${I}"
+			mkdir -p "$_TEMP_MOUNT/flashcast-backups/backup-${I}"
 		fi
         	echo "flashcast-backups/backup-${I}" > /tmp/backup_dir
 	fi
@@ -121,9 +121,9 @@ backup_mtd_partition() {
         # 1: uses ALOT less space
         # 2: dumps of this partition do not write back properly
 	if test "${1}" = "userdata" ; then
-		dry_run "Would backup ${1} to $_TEMPMOUNT/$_BACKUPFOLDER/${1}.zip"
+		dry_run "Would backup ${1} to $_TEMP_MOUNT/$_BACKUPFOLDER/${1}.zip"
 		if test -z "$DRY_RUN" ; then
-			log "Backing Up ${1} to $_TEMPMOUNT/$_BACKUPFOLDER/${1}.zip"
+			log "Backing Up ${1} to $_TEMP_MOUNT/$_BACKUPFOLDER/${1}.zip"
 			_DATAFOLDER="$(mktemp -d)"
 			if ! mount "/dev/mtdblock5" "$_DATAFOLDER" ; then
 				log "Failed to Mount $_PARTITION to $_DATAFOLDER"
@@ -131,7 +131,7 @@ backup_mtd_partition() {
 				return 1;
 			else
 				cd $_DATAFOLDER
-				if ! zip -qry $_TEMPMOUNT/$_BACKUPFOLDER/${1}.zip ./* -x \*wpa_ctrl\* ; then
+				if ! zip -qry $_TEMP_MOUNT/$_BACKUPFOLDER/${1}.zip ./* -x \*wpa_ctrl\* ; then
 					fatal "Error while compressing contents of userdata, aborting."
 					return 1;
 				fi
@@ -142,22 +142,22 @@ backup_mtd_partition() {
 			fi
 		fi
 	else
-		dry_run "Would backup ${1} to $_TEMPMOUNT/$_BACKUPFOLDER/${1}.img"
+		dry_run "Would backup ${1} to $_TEMP_MOUNT/$_BACKUPFOLDER/${1}.img"
 		if test -z "$DRY_RUN" ; then
-			log "Backing Up ${1} to $_TEMPMOUNT/$_BACKUPFOLDER/${1}.img"
-			if ! nanddump -q -f "${_TEMPMOUNT}/${_BACKUPFOLDER}/${1}.img" "/dev/${_PARTITION}"; then
-				fatal "Error Saving ${1} to $_TEMPMOUNT/$_BACKUPFOLDER/${1}.img"
+			log "Backing Up ${1} to $_TEMP_MOUNT/$_BACKUPFOLDER/${1}.img"
+			if ! nanddump -q -f "${_TEMP_MOUNT}/${_BACKUPFOLDER}/${1}.img" "/dev/${_PARTITION}"; then
+				fatal "Error Saving ${1} to $_TEMP_MOUNT/$_BACKUPFOLDER/${1}.img"
 				return 1;
 			fi
 		fi
 	fi
 
 	#Do our own Cleanup
-	umount ${_TEMPMOUNT} && rm -r ${_TEMPMOUNT}
+	umount ${_TEMP_MOUNT} && rm -r ${_TEMP_MOUNT}
 }
 
 # restore_mtd_partition
-# Used to Restore dumps bade by backup_mtd_partition.
+# Used to Restore dumps made by backup_mtd_partition.
 #
 # Parameters:
 #   $1: The name (NOT number) of the MTD partition to restore.
@@ -172,20 +172,20 @@ restore_mtd_partition() {
 	fi
 	
 	# We need a mount point to get the images, and again, files are too big for /tmp
-	_TEMPMOUNT="$(mktemp -d)"
-	if ! mount "/dev/sda1" "$_TEMPMOUNT" ; then
-		log "Could not mount /dev/sda1 to $_TEMPMOUNT"
-		rm -r ${_TEMPMOUNT}
+	_TEMP_MOUNT="$(mktemp -d)"
+	if ! mount "/dev/sda1" "$_TEMP_MOUNT" ; then
+		log "Could not mount /dev/sda1 to $_TEMP_MOUNT"
+		rm -r ${_TEMP_MOUNT}
 		return 1;
 	fi
         
 	# Does the backup even exist?	
-	if ! test -d "${_TEMPMOUNT}/flashcast-backups/backup-${2}" ; then	
+	if ! test -d "${_TEMP_MOUNT}/flashcast-backups/backup-${2}" ; then	
 		fatal "Backup Folder backup-${2} Does not exist"
 	fi
     	# are we data? otherwise, use nandwrite.
 	if test "${1}" = "userdata" ; then
-		_RESTOREIMAGE="${_TEMPMOUNT}/flashcast-backups/backup-${2}/${1}.zip"
+		_RESTOREIMAGE="${_TEMP_MOUNT}/flashcast-backups/backup-${2}/${1}.zip"
 		dry_run "Would restore ${1} from ${_RESTOREIMAGE}"
 		if test -z "$DRY_RUN" ; then
 			if ! test -f "${_RESTOREIMAGE}" ; then	
@@ -213,7 +213,7 @@ restore_mtd_partition() {
 			fi
 		fi
 	else
-		_RESTOREIMAGE="${_TEMPMOUNT}/flashcast-backups/backup-${2}/${1}.img"
+		_RESTOREIMAGE="${_TEMP_MOUNT}/flashcast-backups/backup-${2}/${1}.img"
 		dry_run "Would restore ${1} from ${_RESTOREIMAGE}"
 		if test -z "$DRY_RUN" ; then
 			if ! test -f "${_RESTOREIMAGE}" ; then	
@@ -229,7 +229,7 @@ restore_mtd_partition() {
 	fi
 
 	#Do our own Cleanup
-	umount ${_TEMPMOUNT} && rm -r ${_TEMPMOUNT}
+	umount ${_TEMP_MOUNT} && rm -r ${_TEMP_MOUNT}
 }
 
 # flash_mtd_partition

--- a/src/flash-image
+++ b/src/flash-image
@@ -81,6 +81,157 @@ mtd_lookup() {
 	fi
 }
 
+# backup_mtd_partition
+# Used to Dump an MTP partition.
+#
+# Parameters:
+# $1: The name (NOT number) of the MTD partition to dump.
+# Returns: 0 on success, 1 on failure.
+backup_mtd_partition() {
+	_PARTITION="$(mtd_lookup "$1")"
+	if test "$?" -ne 0 ; then
+		return 1;
+	fi
+	
+	# I know this is bad, but we can't store this in /tmp if images are there due to space
+	_TEMPMOUNT="$(mktemp -d)"
+	if ! mount "/dev/sda1" "$_TEMPMOUNT" ; then
+		log "Could not mount /dev/sda1 to $_TEMPMOUNT"
+		rm -r ${_TEMPMOUNT}
+		return 1;
+	fi
+
+	# Do we know the mount point? We do this so all backups go to the same folder
+	if ! test -f "/tmp/backup_dir" ; then
+		I=1
+		while test -d "$_TEMPMOUNT/flashcast-backups/backup-${I}/" ; do
+                	I="$((I+1))"
+		done
+		dry_run "Would create $_TEMPMOUNT/flashcast-backups/backup-${I}"
+		if test -z "$DRY_RUN" ; then
+			mkdir -p "$_TEMPMOUNT/flashcast-backups/backup-${I}"
+		fi
+        	echo "flashcast-backups/backup-${I}" > /tmp/backup_dir
+	fi
+	_BACKUPFOLDER="$(cat /tmp/backup_dir)"
+        
+        # are we data? otherwise, use nanddump.
+        #
+        # We do this because dd & nanddump...
+        # 1: uses ALOT less space
+        # 2: dumps of this partition do not write back properly
+	if test "${1}" = "userdata" ; then
+		dry_run "Would backup ${1} to $_TEMPMOUNT/$_BACKUPFOLDER/${1}.zip"
+		if test -z "$DRY_RUN" ; then
+			log "Backing Up ${1} to $_TEMPMOUNT/$_BACKUPFOLDER/${1}.zip"
+			_DATAFOLDER="$(mktemp -d)"
+			if ! mount "/dev/mtdblock5" "$_DATAFOLDER" ; then
+				log "Failed to Mount $_PARTITION to $_DATAFOLDER"
+				rm -r ${_DATAFOLDER}
+				return 1;
+			else
+				cd $_DATAFOLDER
+				if ! zip -qry $_TEMPMOUNT/$_BACKUPFOLDER/${1}.zip ./* -x \*wpa_ctrl\* ; then
+					fatal "Error while compressing contents of userdata, aborting."
+					return 1;
+				fi
+				cd - > /dev/null
+	
+				# userdata backups needs some extra cleanup love
+				umount ${_DATAFOLDER} && rm -r ${_DATAFOLDER}
+			fi
+		fi
+	else
+		dry_run "Would backup ${1} to $_TEMPMOUNT/$_BACKUPFOLDER/${1}.img"
+		if test -z "$DRY_RUN" ; then
+			log "Backing Up ${1} to $_TEMPMOUNT/$_BACKUPFOLDER/${1}.img"
+			if ! nanddump -q -f "${_TEMPMOUNT}/${_BACKUPFOLDER}/${1}.img" "/dev/${_PARTITION}"; then
+				fatal "Error Saving ${1} to $_TEMPMOUNT/$_BACKUPFOLDER/${1}.img"
+				return 1;
+			fi
+		fi
+	fi
+
+	#Do our own Cleanup
+	umount ${_TEMPMOUNT} && rm -r ${_TEMPMOUNT}
+}
+
+# restore_mtd_partition
+# Used to Restore dumps bade by backup_mtd_partition.
+#
+# Parameters:
+#   $1: The name (NOT number) of the MTD partition to restore.
+#   $2: The number of the backup to restore
+# Returns: 0 on success, 1 on failure.
+restore_mtd_partition() {
+	_PARTITION="$(mtd_lookup "$1")"
+	if test "$?" -ne 0 ; then
+		return 1;
+	elif test -z "$2" ; then
+        fatal "Error, No Backup Selected."
+	fi
+	
+	# We need a mount point to get the images, and again, files are too big for /tmp
+	_TEMPMOUNT="$(mktemp -d)"
+	if ! mount "/dev/sda1" "$_TEMPMOUNT" ; then
+		log "Could not mount /dev/sda1 to $_TEMPMOUNT"
+		rm -r ${_TEMPMOUNT}
+		return 1;
+	fi
+        
+	# Does the backup even exist?	
+	if ! test -d "${_TEMPMOUNT}/flashcast-backups/backup-${2}" ; then	
+		fatal "Backup Folder backup-${2} Does not exist"
+	fi
+    	# are we data? otherwise, use nandwrite.
+	if test "${1}" = "userdata" ; then
+		_RESTOREIMAGE="${_TEMPMOUNT}/flashcast-backups/backup-${2}/${1}.zip"
+		dry_run "Would restore ${1} from ${_RESTOREIMAGE}"
+		if test -z "$DRY_RUN" ; then
+			if ! test -f "${_RESTOREIMAGE}" ; then	
+				fatal "Image File ${_RESTOREIMAGE} Does not exist"
+			fi
+			log "Restoring ${1} from ${_RESTOREIMAGE}"
+			_DATAFOLDER="$(mktemp -d)"
+			if ! mount "/dev/mtdblock5" "$_DATAFOLDER" ; then
+				log "Failed to Mount $_PARTITION to $_DATAFOLDER"
+				rm -r ${_DATAFOLDER}
+				return 1;
+			else
+				if ! unzip -oKXq ${_RESTOREIMAGE} -d ${_DATAFOLDER} ; then
+					fatal "Error while restoring contents of userdata, aborting."
+					return 1;
+				fi
+				
+				# For some reason the device name will not read its name unless we change permissions
+				if test -f "${_DATAFOLDER}/chrome/.eureka.conf" ; then
+					chmod 666 "${_DATAFOLDER}/chrome/.eureka.conf"
+				fi
+				
+				# userdata backups needs some extra cleanup love
+				umount ${_DATAFOLDER} && rm -r ${_DATAFOLDER}
+			fi
+		fi
+	else
+		_RESTOREIMAGE="${_TEMPMOUNT}/flashcast-backups/backup-${2}/${1}.img"
+		dry_run "Would restore ${1} from ${_RESTOREIMAGE}"
+		if test -z "$DRY_RUN" ; then
+			if ! test -f "${_RESTOREIMAGE}" ; then	
+				fatal "Image File ${_RESTOREIMAGE} Does not exist"
+			fi
+			log "Restoring ${1} from ${_RESTOREIMAGE}"
+			flash_erase -q "/dev/${_PARTITION}" 0 0 
+			if ! nandwrite -qp "/dev/${_PARTITION}" "$_RESTOREIMAGE"; then
+				fatal "Error Restoring ${1} from ${_RESTOREIMAGE}"
+				return 1;
+			fi
+		fi
+	fi
+
+	#Do our own Cleanup
+	umount ${_TEMPMOUNT} && rm -r ${_TEMPMOUNT}
+}
+
 # flash_mtd_partition
 # Writes an image to an MTD partition.
 #

--- a/src/flasher
+++ b/src/flasher
@@ -46,6 +46,15 @@ select_sequential_dir() {
 	echo "${1}/${I}"
 }
 
+unmount_images() {
+	log "Removing large temp directory"
+	rm -rf "$LARGE_TEMP_DIR"
+
+	log "Unmounting and removing ${IMAGES_DIR}"
+	umount "$IMAGES_DIR"
+	rmdir "$IMAGES_DIR"
+}
+
 # Check hardware version.
 if ! grep -qe '\bandroidboot\.hardware=eureka-b3\b' /proc/cmdline ; then
 	fatal "Unsupported hardware! This script is designed for the original Chromecast."
@@ -105,15 +114,6 @@ if test -f "${IMAGES_DIR}/dry_run" ; then
 	export DRY_RUN=1
 fi
 
-unmount_images() {
-	log "Removing large temp directory"
-	rm -rf "$LARGE_TEMP_DIR"
-
-	log "Unmounting and removing ${IMAGES_DIR}"
-	umount "$IMAGES_DIR"
-	rmdir "$IMAGES_DIR"
-}
-
 if test -f "${IMAGES_DIR}/init_partitions" ; then
 	unmount_images
 	log "init_partitions file is present, setting up partitions"
@@ -140,9 +140,22 @@ else
 	else
 		log "${IMAGES_DIR} is not writable, not using a runtime directory"
 	fi
+	
+	# Check if we are doing a backup, and only work when running from USB
+	if test -f "${IMAGES_DIR}/full_backup" ; then
+		if test "$BOOT_MODE" = usb ; then
+			log "full_backup flag detected, backing up partitions"
+			log_cmd flash-image '/usr/share/flasher/full-backup'
+		else
+			fatal "full_backup flag detected, but backups are disabled in non-USB boot modes"
+		fi
+	fi
 
 	# Check for images.
-	if test "$BOOT_MODE" = recovery && has_recovery_param '--wipe_data' ; then
+	if test -f "${IMAGES_DIR}/full_restore" ; then
+		log "full_restore flag detected, restoring partitions from ./flashcast-backups/backup-$(cat ${IMAGES_DIR}/full_restore)"
+		log_cmd flash-image '/usr/share/flasher/full-restore' "$(cat ${IMAGES_DIR}/full_restore)"
+	elif test "$BOOT_MODE" = recovery && has_recovery_param '--wipe_data' ; then
 		log "Factory reset requested, performing"
 		log_cmd flash-image '/usr/share/flasher/factory-reset'
 	elif test -f "${IMAGES_DIR}/eureka_image.zip" ; then
@@ -162,6 +175,8 @@ else
 			IGNORE_ERRORS=1
 		fi
 		log_cmd flash-image '/usr/share/flasher/iterate-images' "${IMAGES_DIR}/flashcast-mods" "$IGNORE_ERRORS"
+	elif test -f "/tmp/backup_dir" ; then
+		log "Backups Completed Successfully"
 	else
 		fatal "No images found on ${IMAGES_DEVICE}"
 	fi

--- a/src/flasher
+++ b/src/flasher
@@ -46,15 +46,6 @@ select_sequential_dir() {
 	echo "${1}/${I}"
 }
 
-unmount_images() {
-	log "Removing large temp directory"
-	rm -rf "$LARGE_TEMP_DIR"
-
-	log "Unmounting and removing ${IMAGES_DIR}"
-	umount "$IMAGES_DIR"
-	rmdir "$IMAGES_DIR"
-}
-
 # Check hardware version.
 if ! grep -qe '\bandroidboot\.hardware=eureka-b3\b' /proc/cmdline ; then
 	fatal "Unsupported hardware! This script is designed for the original Chromecast."
@@ -113,6 +104,15 @@ if test -f "${IMAGES_DIR}/dry_run" ; then
 	log "dry_run file is present, not performing destructive commands"
 	export DRY_RUN=1
 fi
+
+unmount_images() {
+	log "Removing large temp directory"
+	rm -rf "$LARGE_TEMP_DIR"
+
+	log "Unmounting and removing ${IMAGES_DIR}"
+	umount "$IMAGES_DIR"
+	rmdir "$IMAGES_DIR"
+}
 
 if test -f "${IMAGES_DIR}/init_partitions" ; then
 	unmount_images


### PR DESCRIPTION
This adds the ability to do system backups and restores using the flag files full_backup and full_restore, as well as the functions backup_mtd_partition and restore_mtd_partition which can be called from a image file.

Before this is merged, https://github.com/tchebb/eureka_buildroot/pull/2 must be merged upstream otherwise these features will not function properly.
