### PR TITLE
Add Support for Flashing LED During Flashing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ install: all
 	$(INSTALL) -d '$(DESTDIR)/usr/sbin'
 	$(INSTALL) -p src/flasher '$(DESTDIR)/usr/sbin'
 	$(INSTALL) -p src/flash-image '$(DESTDIR)/usr/sbin'
+	$(INSTALL) -p src/led-updating '$(DESTDIR)/usr/sbin'
 	$(INSTALL) -p utils/vercmp '$(DESTDIR)/usr/sbin'
 	$(INSTALL) -d '$(DESTDIR)/etc/init.d'
 	$(INSTALL) -p src/initscript '$(DESTDIR)/etc/init.d/S60flashcast-flasher'

--- a/graphics/splash.svg
+++ b/graphics/splash.svg
@@ -163,14 +163,14 @@
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Open Sans;-inkscape-font-specification:Open Sans Bold"
-       x="155.56741"
+       x="112.48148"
        y="813.01025"
        id="text4137"
        sodipodi:linespacing="125%"><tspan
          sodipodi:role="line"
          id="tspan4139"
-         x="155.56741"
-         y="813.01025">If it's white,</tspan></text>
+         x="112.48148"
+         y="813.01025">If it's blinking white,</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Open Sans;-inkscape-font-specification:Open Sans Bold"

--- a/src/flasher
+++ b/src/flasher
@@ -11,7 +11,16 @@ log() {
 	log_cmd echo "$1"
 }
 
+kill_led() {
+	if test -f /tmp/flash-led.pid ; then
+		kill "$(cat /tmp/flash-led.pid)"
+		rm /tmp/flash-led.pid
+	fi
+	set-led off
+}
+
 fatal() {
+	kill_led
 	set-led red
 	log "SETUP FAILED: ${1}" | tee /etc/motd
 	exit 1
@@ -147,6 +156,10 @@ else
 		log "${IMAGES_DIR} is not writable, not using a runtime directory"
 	fi
 
+	# Start the LED Flash, write pid to file for termination
+	led-updating &
+	echo "$!" > /tmp/flash-led.pid
+
 	# Check for images.
 	if test "$BOOT_MODE" = recovery && has_recovery_param '--wipe_data' ; then
 		log "Factory reset requested, performing"
@@ -176,6 +189,8 @@ fi
 # Reboot the system once we're done flashing, unless the user has prevented it or the script failed.
 if test "$?" -eq 0 ; then
 	log "Flashing succeeded"
+	kill_led
+	set-led white
 	if ! test -f "${IMAGES_DIR}/no_reboot" ; then
 		log "Rebooting"
 		reboot
@@ -184,5 +199,6 @@ if test "$?" -eq 0 ; then
 	fi
 else
 	log "Flashing failed"
+	kill_led
 	set-led red
 fi

--- a/src/led-updating
+++ b/src/led-updating
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# The point of this script is to cycle the LED from off to white, to emulate flashing
+# Terminate by killing the pid assigned to the process.
+
+while [ true ]
+do
+	set-led white
+	usleep 800000
+	set-led off
+	usleep 200000
+done


### PR DESCRIPTION
These patches add support for flashing the white LED during the update process. The Flashing LED is ran by a background shell script that creates a pid file, and is terminated in similar fashion. This means we don't have to poll for a file, and allows for instant termination upon completion or error.
